### PR TITLE
Manisbindra/add scaler feature to support service bus topic

### DIFF
--- a/external-scaler-containerapps-and-k8s/README.md
+++ b/external-scaler-containerapps-and-k8s/README.md
@@ -1,8 +1,10 @@
-# KEDA multi metric scaler - using external scaler trigger
+# Container Apps or K8s based KEDA multi metric external scaler
 
-This sample demonstrates how to use KEDA to scale either a Kubernetes / container apps deployment, based on multiple metrics. Specifically for not scaling up deployment when the error threshold is exceeded, else scaling based on a queue length metric. This keda external scaler implementation scales down 1 instance at a time during scale down.
+This sample demonstrates how to use KEDA to scale either a Kubernetes / container apps deployment, based on multiple metrics. Specifically for not scaling up deployment when the error threshold is exceeded, else scaling based on a queue length metric. This keda external scaler implementation scales down 1 instance at a time during scale down. 
 
-## TODO installation and other details
+## Installation and other details
+
+Use the [install.sh](./infra/bicep/install.sh) script to install the infrastructure.
 
 ## keda external scaler configuration
 
@@ -28,5 +30,8 @@ This sample demonstrates how to use KEDA to scale either a Kubernetes / containe
 * maxReplicas: Maximum number of replicas
 * scalerAddress: Address of the external scaler (such as keda-ext-scaler--uuuuuu.uksouth.azurecontainerapps.io:80) 
 * serviceBusResourceId: Azure resource ID of the service bus
-* serviceBusQueueName: Name of the service bus queue
+* serviceBusQueueOrTopicName: Name of the service bus queue or topic
+* serviceBusTopicSubscriptionName: Name of the service bus topic subscription. For queues, this should be empty("")
+* rate429ErrorsMetricName: Optional. Name of the metric in the Log Analytics workspace / Prometheus that represents the error rate. Default is "rate_429_errors"
+* msgQueueLengthMetricName: Optional. Used when metrics backend is Prometheus. Name of the Prometheus metric that represents the queue length. Default is "msg_queue_length"
 

--- a/external-scaler-containerapps-and-k8s/main.go
+++ b/external-scaler-containerapps-and-k8s/main.go
@@ -13,13 +13,8 @@ import (
 	"github.com/manisbindra/kedaQueueLengthAndErrorRateExternalScaler/replicaCountReaders"
 	"google.golang.org/grpc"
 
-	// "log"
-	// "net"
-
 	"os"
 	"time"
-	// "google.golang.org/grpc/codes"
-	// "google.golang.org/grpc/status"
 )
 
 type ReplicaCountReader interface {
@@ -184,15 +179,6 @@ func (e *ExternalScaler) ValidateSetRequiredMetadata(metadata map[string]string)
 			e.SERVICE_BUS_TOPIC_SUBSCRIPTION_NAME = metadata["serviceBusTopicSubscriptionName"]
 			e.MetricsReader = metricsReaders.NewAzureMetricsReader(e.SERVICE_BUS_RESOURCE_ID, e.SERVICE_BUS_QUEUE_OR_TOPIC_NAME, e.SERVICE_BUS_TOPIC_SUBSCRIPTION_NAME, e.RATE_429_ERRORS_METRIC_NAME, e.LOG_ANALYTICS_WORKSPACE_ID)
 		}
-
-		// if e.SERVICE_BUS_QUEUE_NAME == "" && metadata["serviceBusQueueName"] == "" {
-		// 	return fmt.Errorf("serviceBusQueueName is required for this configuration and not set")
-		// }
-		// if e.SERVICE_BUS_QUEUE_NAME == "" && metadata["serviceBusQueueName"] != "" {
-		// 	fmt.Printf("Setting serviceBusQueueName to %s\n", metadata["serviceBusQueueName"])
-		// 	e.SERVICE_BUS_QUEUE_NAME = metadata["serviceBusQueueName"]
-		// 	e.MetricsReader = metricsReaders.NewAzureMetricsReader(e.SERVICE_BUS_RESOURCE_ID, e.SERVICE_BUS_QUEUE_NAME, e.MSG_QUEUE_LENGTH_METRIC_NAME, e.RATE_429_ERRORS_METRIC_NAME, e.LOG_ANALYTICS_WORKSPACE_ID)
-		// }
 
 	}
 
@@ -417,11 +403,6 @@ func main() {
 		TIME_BETWEEN_SCALE_DOWN_REQUESTS_MINUTES: getEnvInt("TIME_BETWEEN_SCALE_DOWN_REQUESTS_MINUTES", 1),
 		METRICS_BACKEND:                          getEnvString("METRICS_BACKEND", ""),
 		INSTANCE_COMPUTE_BACKEND:                 getEnvString("INSTANCE_COMPUTE_BACKEND", ""),
-
-		// MSG_QUEUE_LENGTH_METRIC_NAME:             getEnvString("MSG_QUEUE_LENGTH_METRIC_NAME", "msg_queue_length"),
-		// RATE_429_ERRORS_METRIC_NAME:              getEnvString("RATE_429_ERRORS_METRIC_NAME", "rate_429_errors"),
-		// PROMETHEUS_ENDPOINT:                      getEnvString("PROMETHEUS_ENDPOINT", ""),
-
 	}
 
 	// wire up metrics and compute backends
@@ -435,10 +416,6 @@ func main() {
 		fmt.Println("INSTANCE_COMPUTE_BACKEND not set, defaulting to kubernetes")
 		e.INSTANCE_COMPUTE_BACKEND = INSTANCE_COMPUTE_BACKEND_KUBERNETES
 	}
-
-	// if e.METRICS_BACKEND == METRICS_BACKEND_PROMETHEUS {
-	// 	e.MetricsReader = metricsReaders.NewPrometheusMetricsReader(e.PROMETHEUS_ENDPOINT, e.MSG_QUEUE_LENGTH_METRIC_NAME, e.RATE_429_ERRORS_METRIC_NAME)
-	// }
 
 	if e.INSTANCE_COMPUTE_BACKEND == INSTANCE_COMPUTE_BACKEND_KUBERNETES {
 		fmt.Printf("Setting Instance compute backend to kubernetes")


### PR DESCRIPTION
    - Add feature to configure external scaler to use either service bus queue or service bus topic
    - Move all configuration settings for service bus queue/topic to scaler metadata
    - Modify bicep to pass service bus topic and subscription to scaler via metadata (instead of service bus queue)
    - Update Readme file to reflect these changes
   