### PR TITLE
Subscriber app metrics

### DIFF
--- a/external-scaler-containerapps-and-k8s/infra/bicep/base.bicep
+++ b/external-scaler-containerapps-and-k8s/infra/bicep/base.bicep
@@ -7,6 +7,10 @@ param location string
 
 param containerRegistryName string
 
+
+var keyVaultName = replace('scaler-${baseName}', '-', '')
+
+
 resource containerRegistry 'Microsoft.ContainerRegistry/registries@2021-12-01-preview' = {
   name: containerRegistryName
   location: location
@@ -15,6 +19,32 @@ resource containerRegistry 'Microsoft.ContainerRegistry/registries@2021-12-01-pr
   }
 
 }
+
+
+
+resource vault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: keyVaultName
+  location: location
+  properties: {
+    accessPolicies:[]
+    enableRbacAuthorization: true
+    enableSoftDelete: true
+    softDeleteRetentionInDays: 90
+    enabledForDeployment: false
+    enabledForDiskEncryption: false
+    enabledForTemplateDeployment: false
+    tenantId: subscription().tenantId
+    sku: {
+      name: 'standard'
+      family: 'A'
+    }
+    networkAcls: {
+      defaultAction: 'Allow'
+      bypass: 'AzureServices'
+    }
+  }
+}
+
 
 output rgName string = resourceGroup().name
 output containerRegistryName string = containerRegistry.name

--- a/external-scaler-containerapps-and-k8s/infra/bicep/keda-workbook.json
+++ b/external-scaler-containerapps-and-k8s/infra/bicep/keda-workbook.json
@@ -1,0 +1,95 @@
+{
+	"version": "Notebook/1.0",
+	"items": [
+		{
+			"type": 1,
+			"content": {
+				"json": "## KEDA scaler workbook\n---\n\nThis workbook captures the common queries/metrics that are relevant for the KEDA scaler sample.\n\nSelect a time range below..."
+			  },
+			"name": "text - 2"
+		},
+		{
+			"type": 9,
+			"content": {
+				"version": "KqlParameterItem/1.0",
+				"parameters": [
+					{
+						"id": "c072a3bd-635a-4ff3-b2d7-806722d380f1",
+						"version": "KqlParameterItem/1.0",
+						"name": "timeRange",
+						"label": "Time Range",
+						"type": 4,
+						"typeSettings": {
+							"selectableValues": [
+								{
+									"durationMs": 300000
+								},
+								{
+									"durationMs": 600000
+								},
+								{
+									"durationMs": 900000
+								},
+								{
+									"durationMs": 1800000
+								},
+								{
+									"durationMs": 3600000
+								},
+								{
+									"durationMs": 14400000
+								},
+								{
+									"durationMs": 43200000
+								},
+								{
+									"durationMs": 86400000
+								},
+								{
+									"durationMs": 172800000
+								},
+								{
+									"durationMs": 259200000
+								}
+							],
+							"allowCustom": true
+						},
+						"timeContext": {
+							"durationMs": 86400000
+						},
+						"value": {
+							"durationMs": 600000
+						}
+					}
+				],
+				"style": "pills",
+				"queryType": 0,
+				"resourceType": "microsoft.operationalinsights/workspaces"
+			},
+			"name": "parameters - 2"
+		},
+		{
+			"type": 3,
+			"content": {
+				"version": "KqlItem/1.0",
+				"query": "AppMetrics\n| where TimeGenerated > {timeRange:start} and TimeGenerated < {timeRange:end}\n| where Name == \"subscriber-app.openai.embeddings.requests\"\n| extend StatusCode = tostring(Properties.status)\n| summarize count=sum(ItemCount) by bin(TimeGenerated, 10s),  StatusCode\n\n",
+				"showQuery": true,
+				"size": 0,
+				"aggregation": 3,
+				"showAnalytics": true,
+				"title": "OpenAI Embeddings Requests by Response Status",
+				"timeContext": {
+					"durationMs": 86400000
+				},
+				"queryType": 0,
+				"resourceType": "microsoft.operationalinsights/workspaces",
+				"visualization": "timechart"
+			},
+			"name": "queryOpenAIEmbeddingsRequests"
+		}
+	],
+	"fallbackResourceIds": [
+		"/subscriptions/f95180d7-b5fc-49c8-a9a7-5b3ee0d8ffc6/resourceGroups/sl-scaler/providers/Microsoft.OperationalInsights/workspaces/aoaiscaler-sl1"
+	],
+	"$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/external-scaler-containerapps-and-k8s/infra/bicep/main.bicep
+++ b/external-scaler-containerapps-and-k8s/infra/bicep/main.bicep
@@ -358,6 +358,7 @@ resource apiWorkloadApp 'Microsoft.App/containerApps@2023-05-01' = {
 
 
             { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', secretRef: 'app-insights-connection-string' }
+            { name: 'OTEL_METRIC_EXPORT_INTERVAL', value: '10000' } // metric export interval in milliseconds
           ]
         }
       ]

--- a/external-scaler-containerapps-and-k8s/infra/bicep/main.bicep
+++ b/external-scaler-containerapps-and-k8s/infra/bicep/main.bicep
@@ -487,6 +487,20 @@ resource apiSim 'Microsoft.App/containerApps@2023-05-01' = {
   }
 }
 
+resource workbook 'Microsoft.Insights/workbooks@2023-06-01' = {
+  name: guid(subscription().subscriptionId, resourceGroup().name, 'keda-workbook')
+  location: location
+  kind: 'shared'
+  properties: {
+    displayName: 'KEDA workbook'
+    description: 'Workbook to show relevant metrics from the system'
+    serializedData: loadTextContent('./keda-workbook.json')
+    sourceId: logAnalytics.id
+    category: 'workbook'
+    version: '1.0'
+  }
+}
+
 output rgName string = resourceGroup().name
 output containerRegistryLoginServer string = containerRegistry.properties.loginServer
 output containerRegistryName string = containerRegistry.name

--- a/subscriber-app/metrics.py
+++ b/subscriber-app/metrics.py
@@ -1,0 +1,17 @@
+from opentelemetry import metrics
+
+meter = metrics.get_meter(__name__)
+
+# dimensions: status
+_histogram_open_ai_embeddings_requests = meter.create_histogram(
+    name="subscriber-app.openai.embeddings.requests",
+    description="Number of OpenAI embeddings requests",
+    unit="requests",
+)
+
+
+def increment_open_ai_retry(status: int):
+    _histogram_open_ai_embeddings_requests.record(
+        1,
+        {"status": str(status)}
+    )

--- a/subscriber-app/requirements.txt
+++ b/subscriber-app/requirements.txt
@@ -3,3 +3,4 @@ azure-identity==1.18.0
 python-dotenv==1.0.1
 jsons==1.6.3
 openai==1.16.1
+azure-monitor-opentelemetry==1.6.2


### PR DESCRIPTION
- Add `subscriber-app.openai.embeddings.requests` metric to subscriber-app with `status` dimension for response status code
- Update metrics export to 10s to reduce the latency of the metrics
- Add Log Analytics workbook
- Wire up app insights for workload and simulator apps (added KeyVault for secret store)
- Update `install.sh` to only build images when the image + tag doesn't exist in the registry

![image](https://github.com/user-attachments/assets/2e37479b-41fd-4b1d-9f23-839043950e55)
